### PR TITLE
Add daily token limit to ai annotation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "solid_cache", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    solid_cache (1.0.7)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     sqlite3 (2.6.0-aarch64-linux-gnu)
     sqlite3 (2.6.0-aarch64-linux-musl)
     sqlite3 (2.6.0-arm-linux-gnu)
@@ -337,6 +341,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   ruby-openai
   selenium-webdriver
+  solid_cache (~> 1.0)
   sqlite3 (>= 2.1)
   stimulus-rails
   tzinfo-data

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -30,7 +30,7 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
     ai_annotation = @ai_annotation.annotate!
-    increment_token_usage(ai_annotation.token_used)
+    increment_token_usage(@ai_annotation.token_used)
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,4 +1,6 @@
 class AiAnnotationsController < ApplicationController
+  DAILY_TOKEN_LIMIT_PER_CLIENT = 10000
+
   def new
     @new_ai_annotation = AiAnnotation.new
   end
@@ -7,9 +9,16 @@ class AiAnnotationsController < ApplicationController
     text = ai_annotation_params[:text]
     prompt = ai_annotation_params[:prompt]
     @new_ai_annotation = AiAnnotation.prepare_with(text, prompt)
-    ai_annotation = @new_ai_annotation.annotate!
 
-    redirect_to "/ai_annotations/#{ai_annotation.uuid}"
+    if within_daily_token_limit?
+      ai_annotation, token_used = @new_ai_annotation.annotate!
+      increment_daily_token_usage(token_used)
+
+      redirect_to "/ai_annotations/#{ai_annotation.uuid}"
+    else
+      flash.now[:alert] = "Daily AI annotate limit reached. Please try again tomorrow."
+      render :new, status: :too_many_requests
+    end
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
@@ -24,9 +33,16 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation = AiAnnotation.find_by(uuid: params[:id])
     @ai_annotation.text = AnnotationConverter.new.to_inline(ai_annotation_params[:content])
     @ai_annotation.prompt = ai_annotation_params[:prompt]
-    ai_annotation = @ai_annotation.annotate!
 
-    redirect_to "/ai_annotations/#{ai_annotation.uuid}"
+    if within_daily_token_limit?
+      ai_annotation, token_used = @ai_annotation.annotate!
+      increment_daily_token_usage(token_used)
+
+      redirect_to "/ai_annotations/#{ai_annotation.uuid}"
+    else
+      flash.now[:alert] = "Daily AI annotate limit reached. Please try again tomorrow."
+      render :edit, status: :too_many_requests
+    end
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
@@ -37,5 +53,18 @@ class AiAnnotationsController < ApplicationController
 
   def ai_annotation_params
     params.require(:ai_annotation).permit(:text, :prompt, :content)
+  end
+
+  def token_used_cache_key
+    "tokens_used:#{request.remote_ip}:#{Date.current}"
+  end
+
+  def within_daily_token_limit?
+    Rails.cache.read(token_used_cache_key).to_i <= DAILY_TOKEN_LIMIT_PER_CLIENT
+  end
+
+  def increment_daily_token_usage(token_used)
+    current_token_used = Rails.cache.read(token_used_cache_key).to_i
+    Rails.cache.write(token_used_cache_key, current_token_used + token_used, expires_in: 24.hours)
   end
 end

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,6 +1,9 @@
 class AiAnnotationsController < ApplicationController
   DAILY_TOKEN_LIMIT_PER_CLIENT = 10000
 
+  before_action :check_daily_token_limit, only: %i[create update]
+  rescue_from Exceptions::DailyTokenLimitExceededError, with: :handle_daily_token_limit_exceeded
+
   def new
     @new_ai_annotation = AiAnnotation.new
   end
@@ -10,15 +13,10 @@ class AiAnnotationsController < ApplicationController
     prompt = ai_annotation_params[:prompt]
     @new_ai_annotation = AiAnnotation.prepare_with(text, prompt)
 
-    if within_daily_token_limit?
-      ai_annotation, token_used = @new_ai_annotation.annotate!
-      increment_daily_token_usage(token_used)
+    ai_annotation, token_used = @new_ai_annotation.annotate!
+    increment_daily_token_usage(token_used)
 
-      redirect_to "/ai_annotations/#{ai_annotation.uuid}"
-    else
-      flash.now[:alert] = "Daily AI annotate limit reached. Please try again tomorrow."
-      render :new, status: :too_many_requests
-    end
+    redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
@@ -34,15 +32,10 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation.text = AnnotationConverter.new.to_inline(ai_annotation_params[:content])
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
-    if within_daily_token_limit?
-      ai_annotation, token_used = @ai_annotation.annotate!
-      increment_daily_token_usage(token_used)
+    ai_annotation, token_used = @ai_annotation.annotate!
+    increment_daily_token_usage(token_used)
 
-      redirect_to "/ai_annotations/#{ai_annotation.uuid}"
-    else
-      flash.now[:alert] = "Daily AI annotate limit reached. Please try again tomorrow."
-      render :edit, status: :too_many_requests
-    end
+    redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
@@ -59,8 +52,22 @@ class AiAnnotationsController < ApplicationController
     "tokens_used:#{request.remote_ip}:#{Date.current}"
   end
 
-  def within_daily_token_limit?
-    Rails.cache.read(token_used_cache_key).to_i <= DAILY_TOKEN_LIMIT_PER_CLIENT
+  def check_daily_token_limit
+    within_token_limit = Rails.cache.read(token_used_cache_key).to_i <= DAILY_TOKEN_LIMIT_PER_CLIENT
+    raise Exceptions::DailyTokenLimitExceededError unless within_token_limit
+  end
+
+  def handle_daily_token_limit_exceeded(e)
+    flash.now[:alert] = "#{e.message}"
+
+    case action_name
+    when "create"
+      @new_ai_annotation = AiAnnotation.prepare_with(ai_annotation_params[:text], ai_annotation_params[:prompt])
+      render :new, status: :too_many_requests
+    when "update"
+      @ai_annotation = AiAnnotation.find_by(uuid: params[:id])
+      render :edit, status: :too_many_requests
+    end
   end
 
   def increment_daily_token_usage(token_used)

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -11,7 +11,7 @@ class AiAnnotationsController < ApplicationController
     @new_ai_annotation = AiAnnotation.prepare_with(text, prompt)
 
     ai_annotation = @new_ai_annotation.annotate!
-    increment_daily_token_usage(@new_ai_annotation.token_used)
+    increment_token_usage(@new_ai_annotation.token_used)
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e
@@ -30,7 +30,7 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
     ai_annotation = @ai_annotation.annotate!
-    increment_daily_token_usage(ai_annotation.token_used)
+    increment_token_usage(ai_annotation.token_used)
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -10,8 +10,8 @@ class AiAnnotationsController < ApplicationController
     prompt = ai_annotation_params[:prompt]
     @new_ai_annotation = AiAnnotation.prepare_with(text, prompt)
 
-    ai_annotation, token_used = @new_ai_annotation.annotate!
-    increment_daily_token_usage(token_used)
+    ai_annotation = @new_ai_annotation.annotate!
+    increment_daily_token_usage(@new_ai_annotation.token_used)
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e
@@ -29,8 +29,8 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation.text = AnnotationConverter.new.to_inline(ai_annotation_params[:content])
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
-    ai_annotation, token_used = @ai_annotation.annotate!
-    increment_daily_token_usage(token_used)
+    ai_annotation = @ai_annotation.annotate!
+    increment_daily_token_usage(ai_annotation.token_used)
 
     redirect_to "/ai_annotations/#{ai_annotation.uuid}"
   rescue => e

--- a/app/controllers/concerns/token_limitable.rb
+++ b/app/controllers/concerns/token_limitable.rb
@@ -33,6 +33,8 @@ module TokenLimitable
     end
   end
 
+  # After used OpenAI API in the controller, call this method to update the token usage.
+  # Give the token used count returned by the API as the argument when calling this method.
   def increment_token_usage(token_used)
     current_token_used = Rails.cache.read(token_used_cache_key).to_i
     Rails.cache.write(token_used_cache_key, current_token_used + token_used, expires_in: 24.hours)

--- a/app/controllers/concerns/token_limitable.rb
+++ b/app/controllers/concerns/token_limitable.rb
@@ -14,7 +14,6 @@ module TokenLimitable
   end
 
   def check_daily_token_limit
-    binding.break
     within_token_limit = Rails.cache.read(token_used_cache_key).to_i <= DAILY_TOKEN_LIMIT_PER_CLIENT
     raise Exceptions::DailyTokenLimitExceededError unless within_token_limit
   end

--- a/app/controllers/concerns/token_limitable.rb
+++ b/app/controllers/concerns/token_limitable.rb
@@ -1,0 +1,39 @@
+module TokenLimitable
+  extend ActiveSupport::Concern
+
+  included do
+    DAILY_TOKEN_LIMIT_PER_CLIENT = 10000
+    before_action :check_daily_token_limit, only: %i[create update]
+    rescue_from Exceptions::DailyTokenLimitExceededError, with: :handle_daily_token_limit_exceeded
+  end
+
+  private
+
+  def token_used_cache_key
+    "tokens_used:#{request.remote_ip}:#{Date.current}"
+  end
+
+  def check_daily_token_limit
+    binding.break
+    within_token_limit = Rails.cache.read(token_used_cache_key).to_i <= DAILY_TOKEN_LIMIT_PER_CLIENT
+    raise Exceptions::DailyTokenLimitExceededError unless within_token_limit
+  end
+
+  def handle_daily_token_limit_exceeded(exception)
+    flash.now[:alert] = exception.message
+
+    case action_name
+    when "create"
+      @new_ai_annotation = AiAnnotation.prepare_with(ai_annotation_params[:text], ai_annotation_params[:prompt])
+      render :new, status: :too_many_requests
+    when "update"
+      @ai_annotation = AiAnnotation.find_by(uuid: params[:id])
+      render :edit, status: :too_many_requests
+    end
+  end
+
+  def increment_daily_token_usage(token_used)
+    current_token_used = Rails.cache.read(token_used_cache_key).to_i
+    Rails.cache.write(token_used_cache_key, current_token_used + token_used, expires_in: 24.hours)
+  end
+end

--- a/app/controllers/concerns/token_limitable.rb
+++ b/app/controllers/concerns/token_limitable.rb
@@ -9,6 +9,8 @@ module TokenLimitable
 
   private
 
+  # Currently, token limits are reset on a date basis.
+  # This is implemented by including the date in the cache key.
   def token_used_cache_key
     "tokens_used:#{request.remote_ip}:#{Date.current}"
   end

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,0 +1,7 @@
+module Exceptions
+  class DailyTokenLimitExceededError < StandardError
+    def initialize(msg = "Daily AI annotate limit reached. Please try again tomorrow.")
+      super(msg)
+    end
+  end
+end

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -1,5 +1,5 @@
 module Exceptions
-  class DailyTokenLimitExceededError < StandardError
+  class TokenLimitExceededError < StandardError
     def initialize(msg = "Daily AI annotate limit reached. Please try again tomorrow.")
       super(msg)
     end

--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -49,8 +49,8 @@ class AiAnnotation < ApplicationRecord
       }
     )
 
-    result = response.dig("choices", 0, "message", "content")
     self.token_used = response.dig("usage", "total_tokens").to_i
+    result = response.dig("choices", 0, "message", "content")
     AiAnnotation.create!(content: result)
   end
 

--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -1,5 +1,5 @@
 class AiAnnotation < ApplicationRecord
-  attr_accessor :text, :prompt
+  attr_accessor :text, :prompt, :token_used
 
   FORMAT_SPECIFICATION = <<~EOS
     Annotate the text according to the prompt with using the following syntax:
@@ -50,10 +50,8 @@ class AiAnnotation < ApplicationRecord
     )
 
     result = response.dig("choices", 0, "message", "content")
-    token_used = response.dig("usage", "total_tokens").to_i
-    annotation = AiAnnotation.create!(content: result)
-
-    [ annotation, token_used ]
+    self.token_used = response.dig("usage", "total_tokens").to_i
+    AiAnnotation.create!(content: result)
   end
 
   private

--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -50,7 +50,10 @@ class AiAnnotation < ApplicationRecord
     )
 
     result = response.dig("choices", 0, "message", "content")
-    AiAnnotation.create!(content: result)
+    token_used = response.dig("usage", "total_tokens").to_i
+    annotation = AiAnnotation.create!(content: result)
+
+    [ annotation, token_used ]
   end
 
   private

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,17 @@
+default: &default
+  store_options:
+    # Cap age of oldest cache entry to fulfill retention policies
+    # max_age: <%= 60.days.to_i %>
+    max_size: <%= 256.megabytes %>
+    namespace: <%= Rails.env %>
+
+development:
+  database: cache
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  database: cache
+  <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,11 +10,13 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
-  <<: *default
-  database: storage/development_cache.sqlite3
-  migrations_paths: db:cache_migrate
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  cache:
+    <<: *default
+    database: storage/development_cache.sqlite3
+    migrations_paths: db:cache_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,9 @@ default: &default
 development:
   <<: *default
   database: storage/development.sqlite3
+  <<: *default
+  database: storage/development_cache.sqlite3
+  migrations_paths: db:cache_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -27,3 +30,7 @@ production:
   primary:
     <<: *default
     database: storage/production.sqlite3
+  cache:
+    <<: *default
+    database: storage/production_cache.sqlite3
+    migrations_paths: db/cache_migrate

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   end
 
   # Change to :null_store to avoid any caching.
-  config.cache_store = :memory_store
+  config.cache_store = :solid_cache_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+ActiveRecord::Schema[7.2].define(version: 1) do
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.binary "key", limit: 1024, null: false
+    t.binary "value", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+end


### PR DESCRIPTION
## 概要
AI Annotationは現状無制限で使用可能でした。
1クライアントから過剰に使用されることを防ぐため、クライアントごとにAIアノテーション量に制限を掛けました。

### 制限方法について
クライアントごとの一日のトークン数で制限を行うようにしました。
1日の上限は仮に1万トークンとしました。

## 作業内容
- SolidCacheの有効化
 - AiAnnotationsController#new, #updateに対してトークン制限を追加

## 動作確認
トークン使用量をログ出力して確認します。
使用量が制限範囲内であれば、リクエストは成功します。
<img width="1907" alt="image" src="https://github.com/user-attachments/assets/f8239cb0-414d-4b68-9339-475dfc6cb514" />


使用量が制限を超えると429エラーを返してリクエストは失敗します。
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/578065ef-a2fa-4783-85b9-4bfacb946480" />

画面上で適切なエラーが表示されます。
|<img width="1333" alt="image" src="https://github.com/user-attachments/assets/c6d1c7e0-be17-4d3f-b796-4969657f47da" />|
|:-|

Edit画面でも同様に動作します。
|<img width="1239" alt="image" src="https://github.com/user-attachments/assets/d269f0fc-0a1f-4ad2-9a0e-7d9c5eab2f92" />|
|:-|