### PR TITLE
Revised textae scroll style

### DIFF
--- a/app/assets/stylesheets/ai_annotation.css
+++ b/app/assets/stylesheets/ai_annotation.css
@@ -54,7 +54,6 @@
   }
 }
 
-
 .button {
   padding: 8px 16px;
   border-radius: 9999px;

--- a/app/assets/stylesheets/ai_annotation.css
+++ b/app/assets/stylesheets/ai_annotation.css
@@ -42,17 +42,18 @@
   margin-top: 40px;
 
   .textae-editor {
-    max-height: 600px;
-    overflow-y: scroll;
+    overflow: hidden;
     border: solid 1px #D9D9D9;
     border-radius: 12px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
-    .textae-control-bar {
-      border-radius: 12px 12px 0 0;
+    .textae-editor__body {
+      max-height: 600px;
+      overflow-y: auto;
     }
   }
 }
+
 
 .button {
   padding: 8px 16px;


### PR DESCRIPTION
## 概要
TextAEのスクロールバーcssを改善しました。

## 改善内容
- スクロールバーが必要な高さではない状態では非表示に変更
- スクロールバーの表示はTextAE全体から、テキストエリア部分のみに表示
- textae-editorクラスにoverflow: hiddenを追加することにより、スクロールバーのスタイルを調整(角を丸く)

## before
|<img width="1210" alt="image" src="https://github.com/user-attachments/assets/4424cf81-5596-4b28-8055-16da660062ae" />|
|:-|

## after
|<img width="1651" alt="image" src="https://github.com/user-attachments/assets/ebe6a02b-3dbc-4d2f-a9d8-7db3ca86c46c" />|
|:-|