### PR TITLE
Bugfix for unexpected token error on JSON.parse

### DIFF
--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -26,7 +26,7 @@ class AiAnnotationsController < ApplicationController
 
   def update
     @ai_annotation = AiAnnotation.find_by(uuid: params[:id])
-    @ai_annotation.text_json = JSON.parse(ai_annotation_params[:content])
+    @ai_annotation.text = ai_annotation_params[:content]
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
     ai_annotation = @ai_annotation.annotate!

--- a/app/models/ai_annotation.rb
+++ b/app/models/ai_annotation.rb
@@ -54,9 +54,6 @@ class AiAnnotation < ApplicationRecord
     AiAnnotation.create!(content: result)
   end
 
-  def text_json=(annotation_json)
-    self.text = SimpleInlineTextAnnotation.generate(annotation_json)
-  end
 
   private
 


### PR DESCRIPTION
## 概要

既存の以下のコードで、`ai_annotation_params[:content]` に シンプルインラインテキストフォーマットが含まれており、つまり、`[` が原因で `JSON.parse` が失敗します。

```
@ai_annotation.text_json = JSON.parse(ai_annotation_params[:content])
```

検討の結果、`ai_annotation_params[:content]` をそのまま `@ai_annotation.text` に代入すれば正しく処理されることがわかりました。
そのため、そのように変更します。

## 動作確認

1. プロンプト「動詞に「verb」とアノテーションしてほしい」を入力し、Annotateボタンを押下します。

<img width="1536" alt="image" src="https://github.com/user-attachments/assets/07e24f4c-51d4-4881-b5cd-1ac52fb42f05" />

2. 正しくアノテーションが実行されます。

<img width="1536" alt="image" src="https://github.com/user-attachments/assets/25e132e1-a301-48d5-89b1-51c997d86cd8" />

3. 続いて、プロンプト「名詞に「noun」とアノテーションしてほしい」と入力し、Annotateボタンを押下します。

<img width="1536" alt="image" src="https://github.com/user-attachments/assets/ad684293-702f-4c78-ba0f-ccf4f782b907" />

4. 正しくアノテーションが実行されます。

<img width="1536" alt="image" src="https://github.com/user-attachments/assets/4eea9ae7-5ca0-4bf2-b19c-52249a3eecd1" />

以上