### PR TITLE
Implement sliding window Part.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,12 @@ gem "bootsnap", require: false
 gem "dotenv-rails"
 gem "ruby-openai"
 
+# Ruby integrations for Elasticsearch (client, API, etc.)
+gem "elasticsearch", "~> 9.0", ">= 9.0.3"
+
+# neural network model for language identification
+gem "cld3", "~> 3.7"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cld3 (3.7.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -105,6 +106,14 @@ GEM
       dotenv (= 3.1.7)
       railties (>= 6.1)
     drb (2.2.1)
+    elastic-transport (8.4.0)
+      faraday (< 3)
+      multi_json
+    elasticsearch (9.0.3)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 9.0.3)
+    elasticsearch-api (9.0.3)
+      multi_json
     erubi (1.13.1)
     event_stream_parser (1.0.0)
     faraday (2.12.2)
@@ -148,6 +157,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_json (1.15.0)
     multipart-post (2.4.1)
     net-http (0.6.0)
       uri
@@ -170,6 +180,8 @@ GEM
     nokogiri (1.18.6-arm-linux-musl)
       racc (~> 1.4)
     nokogiri (1.18.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.6-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.6-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -291,6 +303,7 @@ GEM
     sqlite3 (2.6.0-arm-linux-gnu)
     sqlite3 (2.6.0-arm-linux-musl)
     sqlite3 (2.6.0-arm64-darwin)
+    sqlite3 (2.6.0-x86_64-darwin)
     sqlite3 (2.6.0-x86_64-linux-gnu)
     sqlite3 (2.6.0-x86_64-linux-musl)
     stimulus-rails (1.3.4)
@@ -327,6 +340,7 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin-23
   arm64-darwin-24
+  x86_64-darwin-24
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -335,8 +349,10 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  cld3 (~> 3.7)
   debug
   dotenv-rails
+  elasticsearch (~> 9.0, >= 9.0.3)
   importmap-rails
   jbuilder
   propshaft

--- a/app/errors/relation_crosses_chunk_error.rb
+++ b/app/errors/relation_crosses_chunk_error.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class RelationCrossesChunkError < StandardError; end

--- a/app/models/smart_multilingual_tokenizer.rb
+++ b/app/models/smart_multilingual_tokenizer.rb
@@ -1,0 +1,50 @@
+class SmartMultilingualTokenizer
+  def initialize(client)
+    @client = client
+    @index_name = "smart_multilingual"
+  end
+
+  # Analyze text: detect language and tokenize using Elasticsearch analyzer
+  def analyze_multilingual_text(text)
+    {
+      language: detect_language(text),
+      tokens: tokenize_with_standard_analyzer(text)
+    }
+  end
+
+  # Analyze an array of texts with language detection and tokenization
+  def analyze_mixed_content(texts)
+    texts.map do |text|
+      result = analyze_multilingual_text(text)
+      {
+        original: text,
+        detected_language: result[:language],
+        tokens: result[:tokens],
+        token_count: result[:tokens].size
+      }
+    end
+  end
+
+  private
+
+  # Detect language using CLD3 (refactored to be more idiomatic Ruby)
+  def detect_language(text)
+    lang = CLD3::NNetLanguageIdentifier.new(0, 400).find_language(text)&.language
+    { ja: "ja", ko: "ko", en: "en" }[lang] || "unknown"
+  end
+
+  # Tokenize text using Elasticsearch's analyze API
+  def tokenize_with_standard_analyzer(text)
+    @client.indices.analyze(
+      index: @index_name,
+      body: { analyzer: "standard", text: text }
+    )["tokens"].map do |token|
+      {
+        token: token["token"].downcase,
+        start_offset: token["start_offset"],
+        end_offset: token["end_offset"],
+        type: token["type"]
+      }
+    end
+  end
+end

--- a/app/models/token_chunk.rb
+++ b/app/models/token_chunk.rb
@@ -1,0 +1,181 @@
+class TokenChunk
+  # Initialize Elasticsearch client and tokenizer
+  def initialize
+    @client = Elasticsearch::Client.new(hosts: [ "localhost:9200" ])
+    @tokenizer = SmartMultilingualTokenizer.new(@client)
+  end
+
+  # Generate token chunks from JSON data with a specified window size
+  def from(json_data, window_size: 20)
+    original_text = json_data["text"]
+    original_denotations = json_data["denotations"] || []
+    original_relations = json_data["relations"] || []
+
+    # Return Enumerator if no block is given
+    return enum_for(:from, json_data, window_size: window_size) unless block_given?
+    return if window_size <= 0
+
+    response = @tokenizer.analyze_multilingual_text(original_text)
+    language = response[:language]
+
+    generate_chunks(
+      original_text,
+      original_denotations,
+      original_relations,
+      response[:tokens],
+      window_size,
+      language
+    ) do |chunk|
+      yield chunk
+    end
+  end
+
+  private
+
+  # Main chunk generation loop
+  def generate_chunks(original_text, original_denotations, original_relations, tokens, window_size, language)
+    return if tokens.empty?
+
+    i = 0
+    while i < tokens.size
+      # Get tokens for the current window
+      window_tokens = tokens[i, window_size]
+      break if window_tokens.nil? || window_tokens.empty?
+
+      # Determine chunk range and actual tokens
+      chunk_start, chunk_end, window_tokens = resolve_chunk_range_and_tokens(
+        original_text, tokens, window_tokens, original_denotations, window_size, language
+      )
+
+      # Decide next start index for chunking
+      next_i = window_tokens.any? ? next_chunk_start_index(tokens, i, chunk_end) : i + 1
+
+      if window_tokens.empty?
+        i = next_i
+        next
+      end
+
+      # Build chunk data (text, denotations, relations)
+      chunk_data = build_chunk_data(
+        original_text, chunk_start, chunk_end,
+        original_denotations, original_relations
+      )
+
+      yield(chunk_data)
+      i = next_i
+    end
+  end
+
+  # Decide chunk start/end and which tokens to include
+  def resolve_chunk_range_and_tokens(original_text, tokens, window_tokens, original_denotations, window_size, language)
+    chunk_start = window_tokens.first[:start_offset]
+
+    extended_chunk_end = find_chunk_end_boundary(
+      original_text, chunk_start, tokens, window_size, window_tokens, language
+    )
+
+    actual_tokens = tokens.select { |token| token[:start_offset] >= chunk_start && token[:end_offset] <= extended_chunk_end }
+
+    if (shrink_index = find_denotation_crossing_index(extended_chunk_end, chunk_start, original_denotations, actual_tokens))&.positive?
+      actual_tokens = actual_tokens.first(shrink_index)
+      extended_chunk_end = actual_tokens.last[:end_offset] if actual_tokens.any?
+    end
+
+    [ chunk_start, extended_chunk_end, actual_tokens ]
+  end
+
+  # Calculate the next index to start chunking from
+  def next_chunk_start_index(tokens, i, chunk_end)
+    tokens_consumed = tokens[i..].take_while { _1[:end_offset] <= chunk_end }.size
+    i + [ tokens_consumed, 1 ].max
+  end
+
+  # Build the chunk hash (text, denotations, relations)
+  def build_chunk_data(original_text, chunk_start, chunk_end, original_denotations, original_relations)
+    chunk_text = original_text[chunk_start...chunk_end]
+    denotations = denotations_in_chunk(chunk_end, chunk_start, original_denotations)
+    {
+      "text" => chunk_text,
+      "denotations" => denotations,
+      "relations" => relations_in_chunk(denotations, original_relations)
+    }
+  end
+
+  # Find the end of the chunk by sentence boundary or punctuation
+  def find_chunk_end_boundary(text, current_end, all_tokens, window_size, window_tokens, language)
+    last_found_end = current_end
+    begin_index = current_end
+
+    while current_end < text.length
+      char = text[current_end]
+      # Check for sentence-ending punctuation
+      if char =~ /[\.。！？!?]/
+        last_found_end = current_end + 1
+        current_end += 1
+      end
+      current_end += 1
+
+      # Check if window size is exceeded
+      word_count = text[begin_index..current_end].split(" ").length
+      char_count = current_end - begin_index
+      if window_unit(language, word_count, char_count) > window_size
+        return last_found_end
+      end
+    end
+
+    current_end
+  end
+
+  # Find if any denotation crosses the chunk boundary
+  def find_denotation_crossing_index(chunk_end, chunk_start, original_denotations, window_tokens)
+    return nil if window_tokens.empty?
+
+    original_denotations.each do |d|
+      d_start = d["span"]["begin"]
+      d_end = d["span"]["end"]
+      # If denotation starts in chunk but ends outside, find where to shrink
+      if d_start >= chunk_start && d_start < chunk_end && d_end > chunk_end
+        found_index = window_tokens.find_index { |t| t[:start_offset] >= d_start }
+        return found_index if found_index && found_index > 0
+      end
+    end
+    nil
+  end
+
+  # Extract denotations that are fully inside the chunk
+  def denotations_in_chunk(chunk_end, chunk_start, original_denotations)
+    original_denotations.map do |d|
+      d_start = d["span"]["begin"]
+      d_end = d["span"]["end"]
+      next unless d_start >= chunk_start && d_end <= chunk_end
+      {
+        "id" => d["id"],
+        "span" => { "begin" => d_start - chunk_start, "end" => d_end - chunk_start },
+        "obj" => d["obj"]
+      }
+    end.compact
+  end
+
+  # Extract relations where both subject and object are in the chunk
+  def relations_in_chunk(chunk_denotations, original_relations)
+    chunk_ids = chunk_denotations.map { _1["id"] }
+    original_relations.each_with_object([]) do |r, arr|
+      subj, obj = r["subj"], r["obj"]
+      if chunk_ids.include?(subj) && chunk_ids.include?(obj)
+        arr << r
+      elsif chunk_ids.include?(subj) || chunk_ids.include?(obj)
+        raise RelationCrossesChunkError, "Relation #{r.inspect} crosses chunk boundary"
+      end
+    end
+  end
+
+  # Decide window unit: char count for CJK, token count otherwise
+  def window_unit(language, word_count, char_count)
+    case language
+    when "ja", "ko"
+      char_count
+    else
+      word_count
+    end
+  end
+end

--- a/test/models/token_chunk_test.rb
+++ b/test/models/token_chunk_test.rb
@@ -1,0 +1,630 @@
+require "test_helper"
+
+if ENV["LOCAL_ONLY"]
+  class TokenChunkTest < ActiveSupport::TestCase
+    test "should split into single chunk when all relations fit in window" do
+      json_data = {
+        "text" => "Steve Jobs founded Apple Inc. in 1976. Tim Cook is the current CEO of Apple.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 10 }, "obj" => "Person" },
+          { "id" => "T2", "span" => { "begin" => 19, "end" => 28 }, "obj" => "Organization" },
+          { "id" => "T3", "span" => { "begin" => 39, "end" => 47 }, "obj" => "Person" },
+          { "id" => "T4", "span" => { "begin" => 70, "end" => 75 }, "obj" => "Organization" }
+        ],
+        "relations" => [
+          { "pred" => "founder_of", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "ceo_of", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: 50).to_a
+
+      assert_equal 1, chunks.size
+      assert_equal json_data["text"], chunks.first["text"]
+      assert_equal json_data["denotations"], chunks.first["denotations"]
+      assert_equal json_data["relations"], chunks.first["relations"]
+    end
+
+    test "should split into multiple chunks with small window and no crossing relations" do
+      json_data = {
+        "text" => "Alice met Bob. Carol likes Dave.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 5 }, "obj" => "Person" },
+          { "id" => "T2", "span" => { "begin" => 10, "end" => 13 }, "obj" => "Person" },
+          { "id" => "T3", "span" => { "begin" => 15, "end" => 20 }, "obj" => "Person" },
+          { "id" => "T4", "span" => { "begin" => 27, "end" => 31 }, "obj" => "Person" }
+        ],
+        "relations" => [
+          { "pred" => "met", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "likes", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+
+      # ウィンドウサイズを小さくしても、文ごとに分割されリレーションがまたがらない
+      chunks = TokenChunk.new.from(json_data, window_size: 3).to_a
+
+      assert_equal 2, chunks.size
+
+      # 1つ目のチャンク
+      assert_equal "Alice met Bob.", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 0, "end" => 5 }, "obj" => "Person" },
+                     { "id" => "T2", "span" => { "begin" => 10, "end" => 13 }, "obj" => "Person" }
+                   ], chunks[0]["denotations"]
+      assert_equal [
+                     { "pred" => "met", "subj" => "T1", "obj" => "T2" }
+                   ], chunks[0]["relations"]
+
+      # 2つ目のチャンク
+      assert_equal "Carol likes Dave.", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T3", "span" => { "begin" => 0, "end" => 5 }, "obj" => "Person" },
+                     { "id" => "T4", "span" => { "begin" => 12, "end" => 16 }, "obj" => "Person" }
+                   ], chunks[1]["denotations"]
+      assert_equal [
+                     { "pred" => "likes", "subj" => "T3", "obj" => "T4" }
+                   ], chunks[1]["relations"]
+    end
+
+    test "should raise error when relation crosses chunk boundary" do
+      json_data = {
+        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+          { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+        ],
+        "relations" => [
+          { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
+        ]
+      }
+
+      assert_raises(::RelationCrossesChunkError) do
+        TokenChunk.new.from(json_data, window_size: 3).to_a
+      end
+    end
+
+    test "should raise error when relation crosses chunk with multiple denotations" do
+      json_data = {
+        "text" => "Steve Jobs founded Apple Inc. in 1976. Tim Cook is the current CEO of Apple.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 10 }, "obj" => "Person" },
+          { "id" => "T2", "span" => { "begin" => 19, "end" => 28 }, "obj" => "Organization" },
+          { "id" => "T3", "span" => { "begin" => 39, "end" => 47 }, "obj" => "Person" },
+          { "id" => "T4", "span" => { "begin" => 70, "end" => 75 }, "obj" => "Organization" }
+        ],
+        "relations" => [
+          { "pred" => "founder_of", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "ceo_of", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+
+      assert_raises(::RelationCrossesChunkError) do
+        TokenChunk.new.from(json_data, window_size: [ "Steve Jobs founded Apple Inc. in 1976.".split(" ").length - 1,
+                                                     "Tim Cook is the current CEO of Apple.".split(" ").length - 1 ].max).to_a
+      end
+    end
+
+    test "should split into two chunks with relations in each chunk" do
+      json_data = {
+        "text" => "Elon Musk is a member of the PayPal Mafia. Elon Musk seems to hate Donald Trump.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+          { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" },
+          { "id" => "T3", "span" => { "begin" => 43, "end" => 52 }, "obj" => "Person" },
+          { "id" => "T4", "span" => { "begin" => 67, "end" => 79 }, "obj" => "Person" }
+        ],
+        "relations" => [
+          { "pred" => "member_of", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "hates", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: 9).to_a
+
+      assert_equal 2, chunks.size
+
+      assert_equal "Elon Musk is a member of the PayPal Mafia.", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+                     { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+                   ], chunks[0]["denotations"]
+      assert_equal [ { "pred" => "member_of", "subj" => "T1", "obj" => "T2" } ], chunks[0]["relations"]
+      assert_equal "Elon Musk seems to hate Donald Trump.", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T3", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
+                     { "id" => "T4", "span" => { "begin" => 24, "end" => 36 }, "obj" => "Person" }
+                   ], chunks[1]["denotations"]
+      assert_equal [ { "pred" => "hates", "subj" => "T3", "obj" => "T4" } ], chunks[1]["relations"]
+    end
+
+    test "should raise error and shrink window to avoid crossing denotation" do
+      json_data = {
+        "text" => "Steve Jobs founded Apple Inc. in 1976. Tim Cook is the current CEO of Apple.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 10 }, "obj" => "Person" },
+          { "id" => "T2", "span" => { "begin" => 19, "end" => 28 }, "obj" => "Organization" },
+          { "id" => "T3", "span" => { "begin" => 39, "end" => 47 }, "obj" => "Person" },
+          { "id" => "T4", "span" => { "begin" => 70, "end" => 75 }, "obj" => "Organization" }
+        ],
+        "relations" => [
+          { "pred" => "founder_of", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "ceo_of", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+
+      assert_raises(::RelationCrossesChunkError) do
+        TokenChunk.new.from(json_data, window_size: 4).to_a
+      end
+    end
+
+    test "should split into individual sentences when window size matches sentence morpheme count" do
+      json_data = {
+        "text" => "すべての鳥は卵を産む。ニワトリは鳥である。ゆえに、ニワトリは卵を産む。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 4, "end" => 5 }, "obj" => "bird" },
+          { "id" => "T2", "span" => { "begin" => 6, "end" => 7 }, "obj" => "egg" },
+          { "id" => "T3", "span" => { "begin" => 11, "end" => 15 }, "obj" => "chicken" },
+          { "id" => "T4", "span" => { "begin" => 16, "end" => 17 }, "obj" => "bird" },
+          { "id" => "T5", "span" => { "begin" => 25, "end" => 29 }, "obj" => "chicken" },
+          { "id" => "T6", "span" => { "begin" => 30, "end" => 31 }, "obj" => "egg" }
+        ],
+        "relations" => [
+          { "pred" => "lay", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "lay", "subj" => "T3", "obj" => "T4" },
+          { "pred" => "lay", "subj" => "T5", "obj" => "T6" }
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: [ "すべての鳥は卵を産む。".length,
+                                                             "ニワトリは鳥である。".length,
+                                                             "ゆえに、ニワトリは卵を産む。".length ].max).to_a
+
+      assert_equal 3, chunks.size
+      assert_equal "すべての鳥は卵を産む。", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 4, "end" => 5 }, "obj" => "bird" },
+                     { "id" => "T2", "span" => { "begin" => 6, "end" => 7 }, "obj" => "egg" }
+                   ], chunks[0]["denotations"]
+      assert_equal "ニワトリは鳥である。", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T3", "span" => { "begin" => 0, "end" => 4 }, "obj" => "chicken" },
+                     { "id" => "T4", "span" => { "begin" => 5, "end" => 6 }, "obj" => "bird" }
+                   ], chunks[1]["denotations"]
+      assert_equal "ゆえに、ニワトリは卵を産む。", chunks[2]["text"]
+      assert_equal [
+                     { "id" => "T5", "span" => { "begin" => 4, "end" => 8 }, "obj" => "chicken" },
+                     { "id" => "T6", "span" => { "begin" => 9, "end" => 10 }, "obj" => "egg" }
+                   ], chunks[2]["denotations"]
+    end
+
+
+    test "should split into individual sentences when window size is smaller than longest sentence" do
+      json_data = {
+        "text" => "すべての鳥は卵を産む。ニワトリは鳥である。ゆえに、ニワトリは卵を産む。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 4, "end" => 5 }, "obj" => "bird" },
+          { "id" => "T2", "span" => { "begin" => 6, "end" => 7 }, "obj" => "egg" },
+          { "id" => "T3", "span" => { "begin" => 11, "end" => 15 }, "obj" => "chicken" },
+          { "id" => "T4", "span" => { "begin" => 16, "end" => 17 }, "obj" => "bird" },
+          { "id" => "T5", "span" => { "begin" => 25, "end" => 29 }, "obj" => "chicken" },
+          { "id" => "T6", "span" => { "begin" => 30, "end" => 31 }, "obj" => "egg" }
+        ],
+        "relations" => [
+          { "pred" => "lay", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "lay", "subj" => "T3", "obj" => "T4" },
+          { "pred" => "lay", "subj" => "T5", "obj" => "T6" }
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: [ "すべての鳥は卵を産む。".length + 1,
+                                                             "ニワトリは鳥である。".length + 1,
+                                                             "ゆえに、ニワトリは卵を産む。".length + 1 ].max).to_a
+
+      assert_equal 3, chunks.size
+      assert_equal "すべての鳥は卵を産む。", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 4, "end" => 5 }, "obj" => "bird" },
+                     { "id" => "T2", "span" => { "begin" => 6, "end" => 7 }, "obj" => "egg" }
+                   ], chunks[0]["denotations"]
+      assert_equal "ニワトリは鳥である。", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T3", "span" => { "begin" => 0, "end" => 4 }, "obj" => "chicken" },
+                     { "id" => "T4", "span" => { "begin" => 5, "end" => 6 }, "obj" => "bird" }
+                   ], chunks[1]["denotations"]
+      assert_equal "ゆえに、ニワトリは卵を産む。", chunks[2]["text"]
+      assert_equal [
+                     { "id" => "T5", "span" => { "begin" => 4, "end" => 8 }, "obj" => "chicken" },
+                     { "id" => "T6", "span" => { "begin" => 9, "end" => 10 }, "obj" => "egg" }
+                   ], chunks[2]["denotations"]
+    end
+
+
+    test "should combine multiple sentences when window size exceeds individual sentence length" do
+      json_data = {
+        "text" => "すべての鳥は卵を産む。ニワトリは鳥である。ゆえに、ニワトリは卵を産む。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 4, "end" => 5 }, "obj" => "bird" },
+          { "id" => "T2", "span" => { "begin" => 6, "end" => 7 }, "obj" => "egg" },
+          { "id" => "T3", "span" => { "begin" => 11, "end" => 15 }, "obj" => "chicken" },
+          { "id" => "T4", "span" => { "begin" => 16, "end" => 17 }, "obj" => "bird" },
+          { "id" => "T5", "span" => { "begin" => 25, "end" => 29 }, "obj" => "chicken" },
+          { "id" => "T6", "span" => { "begin" => 30, "end" => 31 }, "obj" => "egg" }
+        ],
+        "relations" => [
+          { "pred" => "lay", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "lay", "subj" => "T3", "obj" => "T4" },
+          { "pred" => "lay", "subj" => "T5", "obj" => "T6" }
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: [ "すべての鳥は卵を産む。ニワトリは鳥である。".length,
+                                                             "ゆえに、ニワトリは卵を産む。".length ].max).to_a
+
+      assert_equal 2, chunks.size
+      assert_equal "すべての鳥は卵を産む。ニワトリは鳥である。", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 4, "end" => 5 }, "obj" => "bird" },
+                     { "id" => "T2", "span" => { "begin" => 6, "end" => 7 }, "obj" => "egg" },
+                     { "id" => "T3", "span" => { "begin" => 11, "end" => 15 }, "obj" => "chicken" },
+                     { "id" => "T4", "span" => { "begin" => 16, "end" => 17 }, "obj" => "bird" }
+                   ], chunks[0]["denotations"]
+      assert_equal "ゆえに、ニワトリは卵を産む。", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T5", "span" => { "begin" => 4, "end" => 8 }, "obj" => "chicken" },
+                     { "id" => "T6", "span" => { "begin" => 9, "end" => 10 }, "obj" => "egg" }
+                   ], chunks[1]["denotations"]
+    end
+
+    test "should handle mixed japanese and english text" do
+      json_data = {
+        "text" => "私はAI engineerです。Machine learningを勉強しています。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 1 }, "obj" => "person" },
+          { "id" => "T2", "span" => { "begin" => 2, "end" => 13 }, "obj" => "profession" },
+          { "id" => "T3", "span" => { "begin" => 17, "end" => 33 }, "obj" => "technology" }
+        ],
+        "relations" => [
+          { "pred" => "profession_of", "subj" => "T1", "obj" => "T2" }  # 同じ文内のrelationのみ
+        ]
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: [ "私はAI engineerです。".length,
+                                                            "Machine learningを勉強しています。".length ].max).to_a
+
+      assert chunks.size >= 1
+      # 混在テキストでもdenotationが正しく処理されるか
+      total_denotations = chunks.sum { |chunk| chunk["denotations"].size }
+      total_relations = chunks.sum { |chunk| chunk["relations"].size }
+      assert_equal 3, total_denotations
+      assert_equal 1, total_relations  # relationを1つに修正
+    end
+
+    test "should handle sentences ending with question marks and exclamations" do
+      json_data = {
+        "text" => "何をしていますか？とても楽しいです！明日も頑張ります。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 12, "end" => 16 }, "obj" => "emotion" },
+          { "id" => "T2", "span" => { "begin" => 20, "end" => 22 }, "obj" => "time" }
+        ],
+        "relations" => []
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 15).to_a  # ウィンドウサイズを大きく
+
+      assert chunks.size >= 1
+      # 各チャンクが適切な文末記号で終わっているか
+      chunks.each do |chunk|
+        assert_match /[。！？]$/, chunk["text"]
+      end
+    end
+
+    test "should handle text with no denotations and relations" do
+      json_data = {
+        "text" => "これは単純なテキストです。アノテーションはありません。",
+        "denotations" => [],
+        "relations" => []
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 8).to_a
+
+      assert chunks.size >= 1
+      chunks.each do |chunk|
+        assert_equal [], chunk["denotations"]
+        assert_equal [], chunk["relations"]
+      end
+    end
+
+    test "should handle overlapping denotations" do
+      json_data = {
+        "text" => "東京大学医学部は有名です。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 4 }, "obj" => "university" },
+          { "id" => "T2", "span" => { "begin" => 0, "end" => 7 }, "obj" => "medical_school" },
+          { "id" => "T3", "span" => { "begin" => 4, "end" => 7 }, "obj" => "department" }
+        ],
+        "relations" => [
+          { "pred" => "part_of", "subj" => "T3", "obj" => "T1" }
+        ]
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 13).to_a
+
+      assert chunks.size >= 1
+      # 重複するdenotationが正しく処理されるか
+      total_denotations = chunks.sum { |chunk| chunk["denotations"].size }
+      assert_equal 3, total_denotations
+    end
+
+    test "should handle zero window size gracefully" do
+      json_data = {
+        "text" => "テストです。",
+        "denotations" => [],
+        "relations" => []
+      }
+
+      # ゼロウィンドウサイズでもエラーにならないか
+      chunks = TokenChunk.new.from(json_data, window_size: 0).to_a
+      assert_equal 0, chunks.size
+    end
+
+    test "should handle very long denotations" do
+      json_data = {
+        "text" => "独立行政法人情報処理推進機構は日本の情報技術分野を支援しています。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 15 }, "obj" => "organization" },
+          { "id" => "T2", "span" => { "begin" => 16, "end" => 18 }, "obj" => "country" },
+          { "id" => "T3", "span" => { "begin" => 19, "end" => 25 }, "obj" => "field" }
+        ],
+        "relations" => []  # relationを削除
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 20).to_a  # ウィンドウサイズを大きく
+
+      assert chunks.size >= 1
+      # 長いdenotationが正しく処理されるか
+      chunks.each do |chunk|
+        chunk["denotations"].each do |denotation|
+          assert denotation["span"]["end"] > denotation["span"]["begin"]
+        end
+      end
+    end
+
+    test "should handle text with numbers and symbols" do
+      json_data = {
+        "text" => "2024年4月1日にOpenAI社のGPT-4が発表されました。価格は$20/月です。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "date" },
+          { "id" => "T2", "span" => { "begin" => 11, "end" => 17 }, "obj" => "company" },
+          { "id" => "T3", "span" => { "begin" => 19, "end" => 24 }, "obj" => "product" },
+          { "id" => "T4", "span" => { "begin" => 33, "end" => 37 }, "obj" => "price" }
+        ],
+        "relations" => []  # relationを削除
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: "2024年4月1日にOpenAI社のGPT-4が発表されました。".length).to_a  # ウィンドウサイズを大きく
+
+      assert chunks.size >= 1
+      # 数字や記号を含むテキストでも正しく処理されるか
+      total_denotations = chunks.sum { |chunk| chunk["denotations"].size }
+      assert_equal 4, total_denotations
+    end
+
+    test "should handle consecutive sentence boundaries" do
+      json_data = {
+        "text" => "終わりです。。。次が始まります。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 3 }, "obj" => "status" },
+          { "id" => "T2", "span" => { "begin" => 7, "end" => 9 }, "obj" => "status" }
+        ],
+        "relations" => []
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 5).to_a
+
+      assert chunks.size >= 1
+      # 連続する句点が正しく処理されるか
+      chunks.each do |chunk|
+        assert_not_empty chunk["text"].strip
+      end
+    end
+
+    test "should provide debug information" do
+      json_data = {
+        "text" => "私は東京で勉強しています。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 1 }, "obj" => "person" }
+        ],
+        "relations" => []
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 5).to_a
+
+      assert chunks.size > 0
+      # 日本語テキストの場合、デバッグ情報が含まれているか
+      chunks.each do |chunk|
+        if chunk.key?("debug_info")
+          assert chunk.key?("morpheme_count")
+          assert chunk["debug_info"].key?("chunk_range")
+          assert chunk["debug_info"].key?("ends_with_sentence_boundary")
+        end
+      end
+    end
+
+    test "should handle multiple relations referencing same entity within sentence" do
+      json_data = {
+        "text" => "太郎は学生で東京に住んでいる優秀な人です。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 2 }, "obj" => "person" },
+          { "id" => "T2", "span" => { "begin" => 3, "end" => 5 }, "obj" => "occupation" },
+          { "id" => "T3", "span" => { "begin" => 6, "end" => 8 }, "obj" => "location" },
+          { "id" => "T4", "span" => { "begin" => 13, "end" => 15 }, "obj" => "attribute" }
+        ],
+        "relations" => [
+          { "pred" => "is_a", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "lives_in", "subj" => "T1", "obj" => "T3" },
+          { "pred" => "has_attribute", "subj" => "T1", "obj" => "T4" }
+        ]
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: "太郎は学生で東京に住んでいる優秀な人です。".length).to_a
+
+      assert_equal 1, chunks.size  # 1文なので1チャンク
+      # 同じエンティティを参照する複数のrelationが正しく処理されるか
+      total_relations = chunks.sum { |chunk| chunk["relations"].size }
+      assert_equal 3, total_relations
+    end
+
+    test "should extend english chunks to include punctuation" do
+      json_data = {
+        "text" => "Hello world! How are you? I'm fine, thanks.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 5 }, "obj" => "greeting" },
+          { "id" => "T2", "span" => { "begin" => 6, "end" => 11 }, "obj" => "object" }
+        ],
+        "relations" => [
+          { "pred" => "greets", "subj" => "T1", "obj" => "T2" }
+        ]
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 3).to_a
+
+      assert chunks.size >= 1
+      # 英語でも句読点が適切に含まれているか
+      chunks.each do |chunk|
+        # 句読点で終わるか、文末であることを確認
+        assert_match /[.!?]$|[^.!?]$/, chunk["text"]
+      end
+    end
+
+    test "should handle very short text" do
+      json_data = {
+        "text" => "短。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 1 }, "obj" => "adjective" }
+        ],
+        "relations" => []
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: 10).to_a
+
+      assert_equal 1, chunks.size
+      assert_equal "短。", chunks[0]["text"]
+      assert_equal 1, chunks[0]["denotations"].size
+    end
+
+    test "should handle relations within single sentence" do
+      json_data = {
+        "text" => "太郎は東京に住んでいる。花子は大阪に住んでいる。",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 2 }, "obj" => "person" },
+          { "id" => "T2", "span" => { "begin" => 3, "end" => 5 }, "obj" => "location" },
+          { "id" => "T3", "span" => { "begin" => 12, "end" => 14 }, "obj" => "person" },
+          { "id" => "T4", "span" => { "begin" => 15, "end" => 17 }, "obj" => "location" }
+        ],
+        "relations" => [
+          { "pred" => "lives_in", "subj" => "T1", "obj" => "T2" },  # 第1文内のrelation
+          { "pred" => "lives_in", "subj" => "T3", "obj" => "T4" }   # 第2文内のrelation
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: [ "太郎は東京に住んでいる。".length,
+                                                            "花子は大阪に住んでいる。".length ].max).to_a
+
+      assert_equal 2, chunks.size
+      assert_equal 1, chunks[0]["relations"].size
+      assert_equal 1, chunks[1]["relations"].size
+    end
+
+    test "should handle korean text with denotations and relations" do
+      json_data = {
+        "text" => "이순신은 조선의 장군이다. 세종대왕은 한글을 창제했다.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 3 }, "obj" => "person" },
+          { "id" => "T2", "span" => { "begin" => 5, "end" => 7 }, "obj" => "country" },
+          { "id" => "T3", "span" => { "begin" => 15, "end" => 19 }, "obj" => "person" },
+          { "id" => "T4", "span" => { "begin" => 21, "end" => 23 }, "obj" => "alphabet" }
+        ],
+        "relations" => [
+          { "pred" => "is_general_of", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "created", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: [ "이순신은 조선의 장군이다.".length, "세종대왕은 한글을 창제했다.".length ].max).to_a
+
+      assert_equal 2, chunks.size
+      assert_equal "이순신은 조선의 장군이다.", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 0, "end" => 3 }, "obj" => "person" },
+                     { "id" => "T2", "span" => { "begin" => 5, "end" => 7 }, "obj" => "country" }
+                   ], chunks[0]["denotations"]
+      assert_equal [
+                     { "pred" => "is_general_of", "subj" => "T1", "obj" => "T2" }
+                   ], chunks[0]["relations"]
+
+      assert_equal "세종대왕은 한글을 창제했다.", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T3", "span" => { "begin" => 0, "end" => 4 }, "obj" => "person" },
+                     { "id" => "T4", "span" => { "begin" => 6, "end" => 8 }, "obj" => "alphabet" }
+                   ], chunks[1]["denotations"]
+      assert_equal [
+                     { "pred" => "created", "subj" => "T3", "obj" => "T4" }
+                   ], chunks[1]["relations"]
+    end
+
+    test "should split korean text with multiple sentences and no relations" do
+      json_data = {
+        "text" => "서울은 대한민국의 수도이다. 부산은 두 번째로 큰 도시이다.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 2 }, "obj" => "city" },
+          { "id" => "T2", "span" => { "begin" => 4, "end" => 8 }, "obj" => "country" },
+          { "id" => "T3", "span" => { "begin" => 16, "end" => 18 }, "obj" => "city" }
+        ],
+        "relations" => []
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: [ "서울은 대한민국의 수도이다.".length, "부산은 두 번째로 큰 도시이다.".length ].max).to_a
+
+      assert_equal 2, chunks.size
+      assert_equal "서울은 대한민국의 수도이다.", chunks[0]["text"]
+      assert_equal [
+                     { "id" => "T1", "span" => { "begin" => 0, "end" => 2 }, "obj" => "city" },
+                     { "id" => "T2", "span" => { "begin" => 4, "end" => 8 }, "obj" => "country" }
+                   ], chunks[0]["denotations"]
+
+      assert_equal "부산은 두 번째로 큰 도시이다.", chunks[1]["text"]
+      assert_equal [
+                     { "id" => "T3", "span" => { "begin" => 0, "end" => 2 }, "obj" => "city" }
+                   ], chunks[1]["denotations"]
+    end
+
+    test "should handle korean text with overlapping denotations" do
+      json_data = {
+        "text" => "대한민국정부청사는 서울에 있다.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 6 }, "obj" => "government" },
+          { "id" => "T2", "span" => { "begin" => 0, "end" => 4 }, "obj" => "country" },
+          { "id" => "T3", "span" => { "begin" => 6, "end" => 8 }, "obj" => "building" },
+          { "id" => "T4", "span" => { "begin" => 10, "end" => 12 }, "obj" => "city" }
+        ],
+        "relations" => [
+          { "pred" => "located_in", "subj" => "T1", "obj" => "T4" }
+        ]
+      }
+      chunks = TokenChunk.new.from(json_data, window_size: json_data["text"].length).to_a
+
+      assert_equal 1, chunks.size
+      assert_equal 4, chunks[0]["denotations"].size
+      assert_equal 1, chunks[0]["relations"].size
+    end
+
+    test "should handle korean text with relation crossing chunk boundary" do
+      json_data = {
+        "text" => "김연아는 피겨스케이팅 선수이다. 그녀는 올림픽 금메달리스트이다.",
+        "denotations" => [
+          { "id" => "T1", "span" => { "begin" => 0, "end" => 3 }, "obj" => "person" },
+          { "id" => "T2", "span" => { "begin" => 5, "end" => 11 }, "obj" => "sport" },
+          { "id" => "T3", "span" => { "begin" => 18, "end" => 20 }, "obj" => "person" },
+          { "id" => "T4", "span" => { "begin" => 22, "end" => 32 }, "obj" => "title" }
+        ],
+        "relations" => [
+          { "pred" => "is", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "equals", "subj" => "T1", "obj" => "T3" },
+          { "pred" => "is", "subj" => "T3", "obj" => "T4" }
+        ]
+      }
+      # 故意に小さいwindowでrelationがまたがるように
+      assert_raises(::RelationCrossesChunkError) do
+        TokenChunk.new.from(json_data, window_size: "김연아는 피겨스케이팅 선수이다. 그".length).to_a
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

スライディングウィンドウを実装するための、入力文字列分割機能を実装しました。

基本的には入力のウィンドウサイズを守るように、ウィンドウサイズを超えないように分割されます。

指定したウィンドウサイズで分割した時にリレーションが途切れる場合は `RelationCrossesChunkError` が発生します。

## 動作確認

ローカル環境での test/models/token_chunk_test.rb による自動テスト
（このテストを実行するにはElasticSearchがインストールされている必要があります）