### PR TITLE
Try to change algorithm

### DIFF
--- a/app/models/annotation_slicer.rb
+++ b/app/models/annotation_slicer.rb
@@ -24,10 +24,10 @@ class AnnotationSlicer
       end_index = denotation["span"]["end"]
       if range.cover?(begin_index..end_index)
         arr << {
-                  "id" => denotation["id"],
-                  "span" => { "begin" => begin_index - range.begin, "end" => end_index - range.begin },
-                  "obj" => denotation["obj"]
-               }
+          "id" => denotation["id"],
+          "span" => { "begin" => begin_index - range.begin, "end" => end_index - range.begin },
+          "obj" => denotation["obj"]
+        }
       elsif (begin_index < range.begin && range.begin < end_index) || (begin_index < range.end && range.end < end_index)
         raise Exceptions::DenotationFragmentedError, "Denotation #{denotation.inspect} fragmented" if @strict_mode
       elsif (begin_index <= range.begin && range.end < end_index) || (begin_index < range.begin && range.end <= end_index)

--- a/app/models/language_detectable.rb
+++ b/app/models/language_detectable.rb
@@ -1,6 +1,6 @@
 module LanguageDetectable
   def self.detect_language(text)
-    return "unknown" if text.nil? || text.empty?
+    raise ArgumentError "parameter 'text' is nil or empty." if text.nil? || text.empty?
     lang = CLD3::NNetLanguageIdentifier.new(0, 400).find_language(text)&.language
     case lang
     when :ja, :ko, :en

--- a/app/models/language_detectable.rb
+++ b/app/models/language_detectable.rb
@@ -1,5 +1,6 @@
 module LanguageDetectable
   def self.detect_language(text)
+    return "unknown" if text.nil? || text.empty?
     lang = CLD3::NNetLanguageIdentifier.new(0, 400).find_language(text)&.language
     case lang
     when :ja, :ko, :en

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -51,7 +51,6 @@ class TokenChunkGenerator
     i = 0
     while i < sentences.size
       chunk_tokens = []
-      chunk_size = 0
       # @window_sizeに収まるだけ文を追加
       while i < sentences.size
         @text = sentences[i].first&.token
@@ -60,7 +59,6 @@ class TokenChunkGenerator
           break
         end
         chunk_tokens.concat(sentences[i])
-        chunk_size = size
         i += 1
       end
       # 1文がwindow_sizeを超える場合はその文だけでチャンク化

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -61,7 +61,7 @@ class TokenChunkGenerator
     if start_offset < @original_text.length
       sentence_boundaries << [ start_offset, @original_text.length ]
     end
-    # 各文範囲に含まれるtokensをグループ化し、文末トークンに��リオドや句点を含める
+    # 各文範囲に含まれるtokensをグループ化し、文末トークンにピリオドや句点を含める
     sentence_boundaries.each do |begin_off, end_off|
       sentence_tokens = @tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
       # 文末記号がoriginal_textに含まれていれば、その部分のトークンも追加

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -116,14 +116,4 @@ class TokenChunkGenerator
   def language
     @language ||= LanguageDetectable.detect_language(@text)
   end
-
-  # Decide window unit: char count for CJK, token count otherwise
-  def window_unit(word_count, char_count)
-    case language
-    when "ja", "ko"
-      char_count
-    else
-      word_count
-    end
-  end
 end

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -51,7 +51,7 @@ class TokenChunkGenerator
     i = 0
     while i < sentences.size
       chunk_tokens = []
-      # @window_sizeに収まるだけ文を追加
+      # Add as many sentences as fit in @window_size
       while i < sentences.size
         @text = sentences[i].first&.token
         size = WindowSizeCalculator.calculate(language, chunk_tokens + sentences[i])

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -26,20 +26,21 @@ class TokenChunkGenerator
       sentence_boundaries << [ start_offset, @original_text.length ]
     end
     # Group tokens contained in each sentence range, add sentence-ending punctuation as SmartMultilingualTokenizer::Token
-    sentence_boundaries.each do |begin_off, end_off|
-      sentence_tokens = tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
-      sentence_text = @original_text[begin_off...end_off]
+    sentence_boundaries.each do |begin_offset, end_offset|
+      sentence_tokens = tokens.select { |token| token.start_offset >= begin_offset && token.end_offset <= end_offset }
+      sentence_text = @original_text[begin_offset...end_offset]
       if sentence_text =~ sentence_end_regex
-        punct_offset = end_off - 1
+        punct_offset = end_offset - 1
         punct_text = @original_text[punct_offset]
         unless sentence_tokens.any? { |t| t.start_offset == punct_offset }
           # Generate sentence-ending punctuation token with SmartMultilingualTokenizer::Token
-          punct_token = SmartMultilingualTokenizer::Token.new(punct_text, punct_offset, end_off)
+          punct_token = SmartMultilingualTokenizer::Token.new(punct_text, punct_offset, punct_offset + 1, "punctuation")
           sentence_tokens << punct_token
         end
       end
       sentences << sentence_tokens unless sentence_tokens.empty?
     end
+
     sentences
   end
 
@@ -62,13 +63,13 @@ class TokenChunkGenerator
       sentence_boundaries << [ start_offset, @original_text.length ]
     end
     # Group tokens contained in each sentence range, include period or punctuation in sentence-end token
-    sentence_boundaries.each do |begin_off, end_off|
-      sentence_tokens = @tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
+    sentence_boundaries.each do |begin_offset, end_offset|
+      sentence_tokens = @tokens.select { |token| token.start_offset >= begin_offset && token.end_offset <= end_offset }
       # If sentence-ending punctuation is in original_text, add token for that part
-      sentence_text = @original_text[begin_off...end_off]
+      sentence_text = @original_text[begin_offset...end_offset]
       punct_token = nil
       if sentence_text =~ sentence_end_regex
-        punct_offset = end_off - 1
+        punct_offset = end_offset - 1
         punct_text = @original_text[punct_offset]
         # If not tokenized, add as custom token
         unless sentence_tokens.any? { |t| t.start_offset == punct_offset }
@@ -100,6 +101,7 @@ class TokenChunkGenerator
       chunk_data = @slicer.annotation_in chunk_begin..chunk_end
       chunks << chunk_data
     end
+
     chunks
   end
 

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -116,66 +116,8 @@ class TokenChunkGenerator
     end
   end
 
-  # Decide chunk start/end and which tokens to include
-  def resolve_chunk_range_and_tokens(window_tokens)
-    chunk_begin = window_tokens.first.start_offset
-
-    extended_chunk_end = find_chunk_end_boundary @original_text, chunk_begin
-
-    actual_tokens = @tokens.select { |token| chunk_begin <= token.start_offset && token.end_offset <= extended_chunk_end }
-
-    if (shrink_index = find_denotation_crossing_index(chunk_begin, extended_chunk_end, actual_tokens))&.positive?
-      actual_tokens = actual_tokens.first shrink_index
-      extended_chunk_end = actual_tokens.last.end_offset if actual_tokens.any?
-    end
-
-    [ chunk_begin, extended_chunk_end, actual_tokens ]
-  end
-
-  # Find the end of the chunk by sentence boundary or punctuation
-  def find_chunk_end_boundary(text, current_end)
-    last_found_end = current_end
-    begin_index = current_end
-    @text = text
-
-    while current_end < text.length
-      char = text[current_end]
-      # Check for sentence-ending punctuation
-      if char =~ /[\.。！？!?]/
-        last_found_end = current_end + 1
-        current_end += 1
-      end
-      current_end += 1
-
-      # Check if window size is exceeded
-      word_count = text[begin_index..current_end].split(" ").length
-      char_count = current_end - begin_index
-      if window_unit(word_count, char_count) > @window_size
-        return last_found_end
-      end
-    end
-
-    current_end
-  end
-
   def language
     @language ||= LanguageDetectable.detect_language(@text)
-  end
-
-  # Find if any denotation crosses the chunk boundary
-  def find_denotation_crossing_index(chunk_begin, chunk_end, window_tokens)
-    return nil if window_tokens.empty?
-
-    @original_denotations.each do |d|
-      d_begin = d["span"]["begin"]
-      d_end = d["span"]["end"]
-      # If denotation starts in chunk but ends outside, find where to shrink
-      if chunk_begin <= d_begin && d_begin < chunk_end && chunk_end < d_end
-        found_index = window_tokens.find_index { |t| d_begin <= t[:start_offset] }
-        return found_index if found_index && found_index > 0
-      end
-    end
-    nil
   end
 
   # Decide window unit: char count for CJK, token count otherwise

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -89,12 +89,12 @@ class TokenChunkGenerator
     start_offset = 0
     @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
       end_offset = start_offset + sentence.length
-      sentence_boundaries << [start_offset, end_offset]
+      sentence_boundaries << [ start_offset, end_offset ]
       start_offset = end_offset
     end
     # Remaining sentence (if no sentence-ending punctuation)
     if start_offset < @original_text.length
-      sentence_boundaries << [start_offset, @original_text.length]
+      sentence_boundaries << [ start_offset, @original_text.length ]
     end
     # Group tokens contained in each sentence range, include period or punctuation in sentence-end token
     @sentences ||= sentence_boundaries.each_with_object([]) do |(begin_offset, end_offset), ext_sentences|

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -85,9 +85,14 @@ class TokenChunkGenerator
       chunk_tokens = []
       chunk_size = 0
       # @window_sizeに収まるだけ文を追加
-      while i < sentences.size && (chunk_size + sentences[i].size) <= @window_size
+      while i < sentences.size
+        @text = sentences[i].first&.token
+        size = WindowSizeCalculator.calculate(language, chunk_tokens + sentences[i])
+        if size > @window_size
+          break
+        end
         chunk_tokens.concat(sentences[i])
-        chunk_size += sentences[i].size
+        chunk_size = size
         i += 1
       end
       # 1文がwindow_sizeを超える場合はその文だけでチャンク化

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -25,8 +25,9 @@ class TokenChunkGenerator
     if start_offset < @original_text.length
       sentence_boundaries << [ start_offset, @original_text.length ]
     end
+
     # Group tokens contained in each sentence range, add sentence-ending punctuation as SmartMultilingualTokenizer::Token
-    sentence_boundaries.each do |begin_offset, end_offset|
+    sentence_boundaries.each_with_object([]) do |(begin_offset, end_offset), ext_sentences|
       sentence_tokens = tokens.select { |token| token.start_offset >= begin_offset && token.end_offset <= end_offset }
       sentence_text = @original_text[begin_offset...end_offset]
       if sentence_text =~ sentence_end_regex
@@ -38,10 +39,8 @@ class TokenChunkGenerator
           sentence_tokens << punct_token
         end
       end
-      sentences << sentence_tokens unless sentence_tokens.empty?
+      ext_sentences << sentence_tokens unless sentence_tokens.empty?
     end
-
-    sentences
   end
 
   # Main loop for generating token chunks

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -9,30 +9,97 @@ class TokenChunkGenerator
     @slicer = AnnotationSlicer.new(annotation)
   end
 
+  # トークン列を文単位で分割する（original_textから文区切り位置を検出）
+  def split_tokens_by_sentence(tokens)
+    sentences = []
+    sentence_boundaries = []
+    sentence_end_regex = /[。．.！？!?]/
+    # 文末記号でoriginal_textを分割し、各文のoffset範囲を取得
+    start_offset = 0
+    @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
+      end_offset = start_offset + sentence.length
+      sentence_boundaries << [start_offset, end_offset]
+      start_offset = end_offset
+    end
+    # 残りの文（文末記号がない場合）
+    if start_offset < @original_text.length
+      sentence_boundaries << [start_offset, @original_text.length]
+    end
+    # 各文範囲に含まれるtokensをグループ化し、文末記号はSmartMultilingualTokenizer::Tokenで追加
+    sentence_boundaries.each do |begin_off, end_off|
+      sentence_tokens = tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
+      sentence_text = @original_text[begin_off...end_off]
+      if sentence_text =~ sentence_end_regex
+        punct_offset = end_off - 1
+        punct_text = @original_text[punct_offset]
+        unless sentence_tokens.any? { |t| t.start_offset == punct_offset }
+          # SmartMultilingualTokenizer::Tokenで文末記号トークンを生成
+          punct_token = SmartMultilingualTokenizer::Token.new(punct_text, punct_offset, end_off)
+          sentence_tokens << punct_token
+        end
+      end
+      sentences << sentence_tokens unless sentence_tokens.empty?
+    end
+    sentences
+  end
+
   # Main loop for generating token chunks
   def generate_chunks
     return [] if @tokens.empty?
     chunks = []
-    i = 0
-    while i < @tokens.size
-      # Select tokens for the current window
-      window_tokens = @tokens[i, @window_size]
-      break if window_tokens.nil? || window_tokens.empty?
-
-      # Determine chunk range and actual tokens
-      chunk_begin, chunk_end, resolved_window_tokens = resolve_chunk_range_and_tokens window_tokens
-
-      if resolved_window_tokens.any?
-        # Build chunk data (text, denotations, relations)
-        chunk_data = @slicer.annotation_in chunk_begin..chunk_end
-        chunks << chunk_data
-
-        i = next_chunk_begin_index(i, chunk_end)
-      else
-        i = i + 1
-      end
+    sentences = []
+    sentence_boundaries = []
+    sentence_end_regex = /[。．.！？!?]/
+    # original_textから文区切り位置を検出
+    start_offset = 0
+    @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
+      end_offset = start_offset + sentence.length
+      sentence_boundaries << [start_offset, end_offset]
+      start_offset = end_offset
     end
-
+    # 残りの文（文末記号がない場合）
+    if start_offset < @original_text.length
+      sentence_boundaries << [start_offset, @original_text.length]
+    end
+    # 各文範囲に含まれるtokensをグループ化し、文末トークンに��リオドや句点を含める
+    sentence_boundaries.each do |begin_off, end_off|
+      sentence_tokens = @tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
+      # 文末記号がoriginal_textに含まれていれば、その部分のトークンも追加
+      sentence_text = @original_text[begin_off...end_off]
+      punct_token = nil
+      if sentence_text =~ sentence_end_regex
+        punct_offset = end_off - 1
+        punct_text = @original_text[punct_offset]
+        # トークン化されていない場合は自作トークンとして追加
+        unless sentence_tokens.any? { |t| t.start_offset == punct_offset }
+          punct_token = SmartMultilingualTokenizer::Token.new(punct_text, punct_offset, punct_offset + 1, "punctuation")
+        end
+      end
+      sentence_tokens << punct_token if punct_token
+      sentences << sentence_tokens unless sentence_tokens.empty?
+    end
+    # チャンク化処理
+    i = 0
+    while i < sentences.size
+      chunk_tokens = []
+      chunk_size = 0
+      # @window_sizeに収まるだけ文を追加
+      while i < sentences.size && (chunk_size + sentences[i].size) <= @window_size
+        chunk_tokens.concat(sentences[i])
+        chunk_size += sentences[i].size
+        i += 1
+      end
+      # 1文がwindow_sizeを超える場合はその文だけでチャンク化
+      if chunk_tokens.empty? && i < sentences.size
+        chunk_tokens = sentences[i]
+        i += 1
+      end
+      next if chunk_tokens.empty?
+      chunk_begin = chunk_tokens.first.start_offset
+      chunk_end = chunk_tokens.last.end_offset
+      chunk_data = @slicer.annotation_in chunk_begin..chunk_end
+      chunks << chunk_data
+    end
     chunks
   end
 

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -82,6 +82,7 @@ class TokenChunkGenerator
   private
 
   def sentences
+    return @sentences if @sentences
     sentences = []
     sentence_boundaries = []
     sentence_end_regex = /[。．.！？!?]/
@@ -97,7 +98,7 @@ class TokenChunkGenerator
       sentence_boundaries << [start_offset, @original_text.length]
     end
     # Group tokens contained in each sentence range, include period or punctuation in sentence-end token
-    sentence_boundaries.each do |begin_offset, end_offset|
+    @sentences ||= sentence_boundaries.each_with_object([]) do |(begin_offset, end_offset), ext_sentences|
       sentence_tokens = @tokens.select { |token| token.start_offset >= begin_offset && token.end_offset <= end_offset }
       # If sentence-ending punctuation is in original_text, add token for that part
       sentence_text = @original_text[begin_offset...end_offset]
@@ -111,10 +112,8 @@ class TokenChunkGenerator
         end
       end
       sentence_tokens << punct_token if punct_token
-      sentences << sentence_tokens unless sentence_tokens.empty?
+      ext_sentences << sentence_tokens unless sentence_tokens.empty?
     end
-
-    @sentences ||= sentences
   end
 
   # Decide chunk start/end and which tokens to include

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -132,13 +132,6 @@ class TokenChunkGenerator
     [ chunk_begin, extended_chunk_end, actual_tokens ]
   end
 
-  # Calculate the next index to start chunking from
-  def next_chunk_begin_index(i, chunk_end)
-    tokens_consumed = @tokens[i..].take_while { it.end_offset <= chunk_end }.size
-
-    i + [ tokens_consumed, 1 ].max
-  end
-
   # Find the end of the chunk by sentence boundary or punctuation
   def find_chunk_end_boundary(text, current_end)
     last_found_end = current_end

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -61,7 +61,7 @@ class TokenChunkGenerator
         chunk_tokens.concat(sentences[i])
         i += 1
       end
-      # 1文がwindow_sizeを超える場合はその文だけでチャンク化
+      # If a single sentence exceeds window_size, chunk only that sentence
       if chunk_tokens.empty? && i < sentences.size
         chunk_tokens = sentences[i]
         i += 1

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -9,23 +9,23 @@ class TokenChunkGenerator
     @slicer = AnnotationSlicer.new(annotation)
   end
 
-  # トークン列を文単位で分割する（original_textから文区切り位置を検出）
+  # Split token sequence by sentence (detect sentence boundaries from original_text)
   def split_tokens_by_sentence(tokens)
     sentences = []
     sentence_boundaries = []
     sentence_end_regex = /[。．.！？!?]/
-    # 文末記号でoriginal_textを分割し、各文のoffset範囲を取得
+    # Split original_text by sentence-ending punctuation and get offset ranges for each sentence
     start_offset = 0
     @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
       end_offset = start_offset + sentence.length
       sentence_boundaries << [ start_offset, end_offset ]
       start_offset = end_offset
     end
-    # 残りの文（文末記号がない場合）
+    # Remaining sentence (if no sentence-ending punctuation)
     if start_offset < @original_text.length
       sentence_boundaries << [ start_offset, @original_text.length ]
     end
-    # 各文範囲に含まれるtokensをグループ化し、文末記号はSmartMultilingualTokenizer::Tokenで追加
+    # Group tokens contained in each sentence range, add sentence-ending punctuation as SmartMultilingualTokenizer::Token
     sentence_boundaries.each do |begin_off, end_off|
       sentence_tokens = tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
       sentence_text = @original_text[begin_off...end_off]
@@ -33,7 +33,7 @@ class TokenChunkGenerator
         punct_offset = end_off - 1
         punct_text = @original_text[punct_offset]
         unless sentence_tokens.any? { |t| t.start_offset == punct_offset }
-          # SmartMultilingualTokenizer::Tokenで文末記号トークンを生成
+          # Generate sentence-ending punctuation token with SmartMultilingualTokenizer::Token
           punct_token = SmartMultilingualTokenizer::Token.new(punct_text, punct_offset, end_off)
           sentence_tokens << punct_token
         end
@@ -50,27 +50,27 @@ class TokenChunkGenerator
     sentences = []
     sentence_boundaries = []
     sentence_end_regex = /[。．.！？!?]/
-    # original_textから文区切り位置を検出
+    # Detect sentence boundaries from original_text
     start_offset = 0
     @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
       end_offset = start_offset + sentence.length
       sentence_boundaries << [ start_offset, end_offset ]
       start_offset = end_offset
     end
-    # 残りの文（文末記号がない場合）
+    # Remaining sentence (if no sentence-ending punctuation)
     if start_offset < @original_text.length
       sentence_boundaries << [ start_offset, @original_text.length ]
     end
-    # 各文範囲に含まれるtokensをグループ化し、文末トークンにピリオドや句点を含める
+    # Group tokens contained in each sentence range, include period or punctuation in sentence-end token
     sentence_boundaries.each do |begin_off, end_off|
       sentence_tokens = @tokens.select { |token| token.start_offset >= begin_off && token.end_offset <= end_off }
-      # 文末記号がoriginal_textに含まれていれば、その部分のトークンも追加
+      # If sentence-ending punctuation is in original_text, add token for that part
       sentence_text = @original_text[begin_off...end_off]
       punct_token = nil
       if sentence_text =~ sentence_end_regex
         punct_offset = end_off - 1
         punct_text = @original_text[punct_offset]
-        # トークン化されていない場合は自作トークンとして追加
+        # If not tokenized, add as custom token
         unless sentence_tokens.any? { |t| t.start_offset == punct_offset }
           punct_token = SmartMultilingualTokenizer::Token.new(punct_text, punct_offset, punct_offset + 1, "punctuation")
         end
@@ -78,7 +78,7 @@ class TokenChunkGenerator
       sentence_tokens << punct_token if punct_token
       sentences << sentence_tokens unless sentence_tokens.empty?
     end
-    # チャンク化処理
+    # Chunking process
     i = 0
     while i < sentences.size
       chunk_tokens = []

--- a/app/models/token_chunk_generator.rb
+++ b/app/models/token_chunk_generator.rb
@@ -18,12 +18,12 @@ class TokenChunkGenerator
     start_offset = 0
     @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
       end_offset = start_offset + sentence.length
-      sentence_boundaries << [start_offset, end_offset]
+      sentence_boundaries << [ start_offset, end_offset ]
       start_offset = end_offset
     end
     # 残りの文（文末記号がない場合）
     if start_offset < @original_text.length
-      sentence_boundaries << [start_offset, @original_text.length]
+      sentence_boundaries << [ start_offset, @original_text.length ]
     end
     # 各文範囲に含まれるtokensをグループ化し、文末記号はSmartMultilingualTokenizer::Tokenで追加
     sentence_boundaries.each do |begin_off, end_off|
@@ -54,12 +54,12 @@ class TokenChunkGenerator
     start_offset = 0
     @original_text.scan(/.*?[。．.！？!?]/m) do |sentence|
       end_offset = start_offset + sentence.length
-      sentence_boundaries << [start_offset, end_offset]
+      sentence_boundaries << [ start_offset, end_offset ]
       start_offset = end_offset
     end
     # 残りの文（文末記号がない場合）
     if start_offset < @original_text.length
-      sentence_boundaries << [start_offset, @original_text.length]
+      sentence_boundaries << [ start_offset, @original_text.length ]
     end
     # 各文範囲に含まれるtokensをグループ化し、文末トークンに��リオドや句点を含める
     sentence_boundaries.each do |begin_off, end_off|

--- a/app/models/window_size_calculator.rb
+++ b/app/models/window_size_calculator.rb
@@ -1,13 +1,13 @@
 class WindowSizeCalculator
-  # window_sizeの単位を言語ごとに判定
-  # 英語: トークン数, 日本語・韓国語: 文字数
+  # Determine window_size unit by language
+  # English: token count, Japanese/Korean: character count
   def self.calculate(language, tokens)
     case language
     when "ja", "ko"
-      # 文字数合計
+      # Total character count
       tokens.map { |t| t.end_offset - t.start_offset }.sum
     else
-      # トークン数
+      # Token count
       tokens.size
     end
   end

--- a/app/models/window_size_calculator.rb
+++ b/app/models/window_size_calculator.rb
@@ -1,0 +1,15 @@
+class WindowSizeCalculator
+  # window_sizeの単位を言語ごとに判定
+  # 英語: トークン数, 日本語・韓国語: 文字数
+  def self.calculate(language, tokens)
+    case language
+    when "ja", "ko"
+      # 文字数合計
+      tokens.map { |t| t.end_offset - t.start_offset }.sum
+    else
+      # トークン数
+      tokens.size
+    end
+  end
+end
+

--- a/app/models/window_size_calculator.rb
+++ b/app/models/window_size_calculator.rb
@@ -12,4 +12,3 @@ class WindowSizeCalculator
     end
   end
 end
-

--- a/test/models/token_chunk_test.rb
+++ b/test/models/token_chunk_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-# if ENV["LOCAL_ONLY"]
+if ENV["LOCAL_ONLY"]
   class TokenChunkTest < ActiveSupport::TestCase
     test "should split into single chunk when all relations fit in window" do
       json_data = {
@@ -644,4 +644,4 @@ require "test_helper"
       end
     end
   end
-# end
+end

--- a/test/models/token_chunk_test.rb
+++ b/test/models/token_chunk_test.rb
@@ -25,7 +25,7 @@ if ENV["LOCAL_ONLY"]
       assert_equal json_data["relations"], chunks.first["relations"]
     end
 
-    test "should split into single chunk when all relations fit in window2" do
+    test "should split into one chunk for long window size" do
       json_data = {
         "text" => "Humpty Dumpty sat on a wall. Humpty Dumpty had a great fall. All the king's horses and all the king's men Couldn't put Humpty together again.",
         "denotations" => [],
@@ -40,7 +40,7 @@ if ENV["LOCAL_ONLY"]
       assert_equal json_data["relations"], chunks.first["relations"]
     end
 
-    test "should split into single chunk when all relations fit in window3" do
+    test "should split into three chunks for short window size" do
       json_data = {
         "text" => "Humpty Dumpty sat on a wall. Humpty Dumpty had a great fall. All the king's horses and all the king's men Couldn't put Humpty together again.",
         "denotations" => [],

--- a/test/models/token_chunk_test.rb
+++ b/test/models/token_chunk_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-if ENV["LOCAL_ONLY"]
+# if ENV["LOCAL_ONLY"]
   class TokenChunkTest < ActiveSupport::TestCase
     test "should split into single chunk when all relations fit in window" do
       json_data = {
@@ -21,6 +21,38 @@ if ENV["LOCAL_ONLY"]
 
       assert_equal 1, chunks.size
       assert_equal json_data["text"], chunks.first["text"]
+      assert_equal json_data["denotations"], chunks.first["denotations"]
+      assert_equal json_data["relations"], chunks.first["relations"]
+    end
+
+    test "should split into single chunk when all relations fit in window2" do
+      json_data = {
+        "text" => "Humpty Dumpty sat on a wall. Humpty Dumpty had a great fall. All the king's horses and all the king's men Couldn't put Humpty together again.",
+        "denotations" => [],
+        "relations" => []
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: 50)
+
+      assert_equal 1, chunks.size
+      assert_equal json_data["text"], chunks.first["text"]
+      assert_equal json_data["denotations"], chunks.first["denotations"]
+      assert_equal json_data["relations"], chunks.first["relations"]
+    end
+
+    test "should split into single chunk when all relations fit in window3" do
+      json_data = {
+        "text" => "Humpty Dumpty sat on a wall. Humpty Dumpty had a great fall. All the king's horses and all the king's men Couldn't put Humpty together again.",
+        "denotations" => [],
+        "relations" => []
+      }
+
+      chunks = TokenChunk.new.from(json_data, window_size: 5)
+
+      assert_equal 3, chunks.size
+      assert_equal "Humpty Dumpty sat on a wall.", chunks[0]["text"]
+      assert_equal "Humpty Dumpty had a great fall.", chunks[1]["text"]
+      assert_equal "All the king's horses and all the king's men Couldn't put Humpty together again.", chunks[2]["text"]
       assert_equal json_data["denotations"], chunks.first["denotations"]
       assert_equal json_data["relations"], chunks.first["relations"]
     end
@@ -68,13 +100,15 @@ if ENV["LOCAL_ONLY"]
 
     test "should raise error when relation crosses chunk boundary" do
       json_data = {
-        "text" => "Elon Musk is a member of the PayPal Mafia.",
+        "text" => "Elon Musk is a member of the PayPal Mafia. He is clever.",
         "denotations" => [
           { "id" => "T1", "span" => { "begin" => 0, "end" => 9 }, "obj" => "Person" },
-          { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" }
+          { "id" => "T2", "span" => { "begin" => 29, "end" => 41 }, "obj" => "Organization" },
+          { "id" => "T3", "span" => { "begin" => 43, "end" => 45 }, "obj" => "Person" }
         ],
         "relations" => [
-          { "pred" => "member_of", "subj" => "T1", "obj" => "T2" }
+          { "pred" => "member_of", "subj" => "T1", "obj" => "T2" },
+          { "pred" => "is", "subj" => "T1", "obj" => "T3" }
         ]
       }
 
@@ -128,7 +162,8 @@ if ENV["LOCAL_ONLY"]
         ],
         "relations" => [
           { "pred" => "founder_of", "subj" => "T1", "obj" => "T2" },
-          { "pred" => "ceo_of", "subj" => "T3", "obj" => "T4" }
+          { "pred" => "ceo_of", "subj" => "T3", "obj" => "T4" },
+          { "pred" => "friend", "subj" => "T1", "obj" => "T3" }
         ]
       }
 
@@ -389,11 +424,11 @@ if ENV["LOCAL_ONLY"]
         "text" => "終わりです。。。次が始まります。",
         "denotations" => [
           { "id" => "T1", "span" => { "begin" => 0, "end" => 3 }, "obj" => "status" },
-          { "id" => "T2", "span" => { "begin" => 7, "end" => 9 }, "obj" => "status" }
+          { "id" => "T2", "span" => { "begin" => 8, "end" => 9 }, "obj" => "status" }
         ],
         "relations" => []
       }
-      chunks = TokenChunk.new.from(json_data, window_size: 5)
+      chunks = TokenChunk.new.from(json_data, window_size: 6)
 
       assert chunks.size >= 1
       # 連続する句点が正しく処理されるか
@@ -520,7 +555,7 @@ if ENV["LOCAL_ONLY"]
         ]
       }
 
-      chunks = TokenChunk.new.from(json_data, window_size: [ "이순신은 조선의 장군이다.".length, "세종대왕은 한글을 창제했다.".length ].max)
+      chunks = TokenChunk.new.from(json_data, window_size: 15)
 
       assert_equal 2, chunks.size
       assert_equal "이순신은 조선의 장군이다.", chunks[0]["text"]
@@ -552,7 +587,7 @@ if ENV["LOCAL_ONLY"]
         ],
         "relations" => []
       }
-      chunks = TokenChunk.new.from(json_data, window_size: [ "서울은 대한민국의 수도이다.".length, "부산은 두 번째로 큰 도시이다.".length ].max)
+      chunks = TokenChunk.new.from(json_data, window_size: 17)
 
       assert_equal 2, chunks.size
       assert_equal "서울은 대한민국의 수도이다.", chunks[0]["text"]
@@ -599,7 +634,8 @@ if ENV["LOCAL_ONLY"]
         "relations" => [
           { "pred" => "is", "subj" => "T1", "obj" => "T2" },
           { "pred" => "equals", "subj" => "T1", "obj" => "T3" },
-          { "pred" => "is", "subj" => "T3", "obj" => "T4" }
+          { "pred" => "is", "subj" => "T3", "obj" => "T4" },
+          { "pred" => "noun", "subj" => "T1", "obj" => "T4" }
         ]
       }
       # 故意に小さいwindowでrelationがまたがるように
@@ -608,4 +644,4 @@ if ENV["LOCAL_ONLY"]
       end
     end
   end
-end
+# end


### PR DESCRIPTION
## 概要

文がウィンドウサイズより大きい場合に正しく文章の分割ができない問題を修正しました。

### 入力

ウィンドウサイズ： 5

<img width="1123" height="573" alt="image" src="https://github.com/user-attachments/assets/0a5c7f8f-bb03-4832-9004-32bbd9347e63" />

### 修正前

<img width="1117" height="102" alt="image" src="https://github.com/user-attachments/assets/64d7410a-7abe-4e97-b158-fb5aecadd0d3" />

### 修正後

<img width="1119" height="137" alt="image" src="https://github.com/user-attachments/assets/fce50e48-c67c-4a70-9455-d716061b27bc" />
