### PR TITLE
Consolidates CI steps into bin/ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,11 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Run bin/ci
-        run: bin/ci
-
-  lint-js-css:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
 
-      - name: Install Node dependencies
-        run: npm ci
-
-      - name: Check JavaScript/CSS with Biome
-        run: npm run check
+      - name: Run bin/ci
+        run: bin/ci

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -4,6 +4,7 @@ CI.run do
   step "Setup", "bin/setup --skip-server"
 
   step "Style: Ruby", "bin/rubocop"
+  step "Style: JavaScript/CSS", "npm ci && npm run check"
 
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
   step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"


### PR DESCRIPTION
Moves JavaScript/CSS linting steps into the `bin/ci` script for unified CI execution.

This simplifies the GitHub Actions workflow configuration and centralizes the CI logic within the `bin/ci` script.