### PR TITLE
Improve controller history management

### DIFF
--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,5 +1,6 @@
 class AiAnnotationsController < ApplicationController
   before_action :set_llm_options, only: [ :new, :create, :edit ]
+  before_action :initialize_guest_history, unless: :user_signed_in?
 
   rescue_from Exceptions::OllamaUnavailableError, with: :handle_ollama_unavailable
   rescue_from SimpleInlineTextAnnotation::RelationWithoutDenotationError, with: :handle_invalid_ai_response
@@ -10,7 +11,7 @@ class AiAnnotationsController < ApplicationController
 
   def new
     @new_ai_annotation = AiAnnotation.new
-    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
+    @history = get_history
     @active_uuid = @ai_annotation&.uuid || params.dig(:ai_annotation, :branch_from_uuid)
     @is_guest = !user_signed_in?
   end
@@ -27,13 +28,16 @@ class AiAnnotationsController < ApplicationController
 
     ai_annotation = @new_ai_annotation.annotate! token, selected_api_key_uuid, selected_model, parent: parent
 
+    # セッションにゲストのヒストリを保存
+    save_to_guest_history(ai_annotation.uuid) unless user_signed_in?
+
     redirect_to edit_ai_annotation_path(ai_annotation.uuid, api_key_uuid: selected_api_key_uuid, model: selected_model)
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
 
     # Set required variables in case of error
-    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
+    @history = get_history
     render :new, status: :unprocessable_entity
   end
 
@@ -41,7 +45,7 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation = AiAnnotation.find_by(uuid: params[:uuid])
     return redirect_to root_path unless @ai_annotation
 
-    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
+    @history = get_history
     @active_uuid = @ai_annotation&.uuid || params.dig(:ai_annotation, :branch_from_uuid)
     @is_guest = !user_signed_in?
   end
@@ -50,7 +54,6 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation = AiAnnotation.find_by(uuid: params[:uuid])
     return redirect_to root_path unless @ai_annotation
 
-    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
     @ai_annotation.annotation = JSON.parse(ai_annotation_params[:content])
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
@@ -61,11 +64,14 @@ class AiAnnotationsController < ApplicationController
 
     ai_annotation = @ai_annotation.annotate! token, selected_api_key_uuid, selected_model, parent: parent
 
+    # セッションにゲストのヒストリを保存
+    save_to_guest_history(ai_annotation.uuid) unless user_signed_in?
+
     redirect_to edit_ai_annotation_path(ai_annotation.uuid, api_key_uuid: selected_api_key_uuid, model: selected_model)
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
-    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
+    @history = get_history
     render :edit, status: :unprocessable_entity
   end
 
@@ -92,6 +98,28 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation&.reload
     @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50) : []
     render :edit, status: :unprocessable_entity
+　end
+
+  def initialize_guest_history
+    session[:guest_ai_annotation_history] ||= []
+  end
+
+  def save_to_guest_history(uuid)
+    return if uuid.blank?
+    session[:guest_ai_annotation_history] ||= []
+    session[:guest_ai_annotation_history].unshift(uuid)
+    session[:guest_ai_annotation_history].uniq!
+    # 最新50件に制限
+    session[:guest_ai_annotation_history] = session[:guest_ai_annotation_history].first(50)
+  end
+
+  def get_history
+    if user_signed_in?
+      AiAnnotation.history_with_branches(limit: 50, user: current_user)
+    else
+      guest_uuids = session[:guest_ai_annotation_history] || []
+      AiAnnotation.guest_history(guest_uuids, limit: 50)
+    end
   end
 
   def ai_annotation_params

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -1,17 +1,16 @@
 class AiAnnotationsController < ApplicationController
-  before_action :authenticate_user!, except: [ :new ]
   before_action :set_llm_options, only: [ :new, :create, :edit ]
 
   rescue_from Exceptions::OllamaUnavailableError, with: :handle_ollama_unavailable
   rescue_from SimpleInlineTextAnnotation::RelationWithoutDenotationError, with: :handle_invalid_ai_response
 
   def index
-    @ai_annotations = AiAnnotation.where(user: current_user)
+    @ai_annotations = current_user ? AiAnnotation.where(user: current_user) : []
   end
 
   def new
     @new_ai_annotation = AiAnnotation.new
-    @history = AiAnnotation.history_with_branches(limit: 50)
+    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
     @active_uuid = @ai_annotation&.uuid || params.dig(:ai_annotation, :branch_from_uuid)
     @is_guest = !user_signed_in?
   end
@@ -19,9 +18,9 @@ class AiAnnotationsController < ApplicationController
   def create
     text = ai_annotation_params[:text]
     prompt = ai_annotation_params[:prompt]
-    @new_ai_annotation = AiAnnotation.prepare_with(text, prompt)
+    @new_ai_annotation = AiAnnotation.prepare_with(text, prompt, current_user)
 
-    token = current_user.id_token if user_signed_in?
+    token = current_user&.id_token
     selected_api_key_uuid = params[:api_key_uuid]
     selected_model = params[:model]
     parent = AiAnnotation.find_by(uuid: ai_annotation_params[:branch_from_uuid]) if ai_annotation_params[:branch_from_uuid].present?
@@ -34,7 +33,7 @@ class AiAnnotationsController < ApplicationController
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
 
     # Set required variables in case of error
-    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50) : []
+    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
     render :new, status: :unprocessable_entity
   end
 
@@ -42,7 +41,7 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation = AiAnnotation.find_by(uuid: params[:uuid])
     return redirect_to root_path unless @ai_annotation
 
-    @history = AiAnnotation.history_with_branches(limit: 50)
+    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
     @active_uuid = @ai_annotation&.uuid || params.dig(:ai_annotation, :branch_from_uuid)
     @is_guest = !user_signed_in?
   end
@@ -51,11 +50,11 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation = AiAnnotation.find_by(uuid: params[:uuid])
     return redirect_to root_path unless @ai_annotation
 
-    @history = AiAnnotation.history_with_branches(limit: 50)
+    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
     @ai_annotation.annotation = JSON.parse(ai_annotation_params[:content])
     @ai_annotation.prompt = ai_annotation_params[:prompt]
 
-    token = current_user.id_token if user_signed_in?
+    token = current_user&.id_token
     selected_api_key_uuid = params[:api_key_uuid]
     selected_model = params[:model]
     parent = AiAnnotation.find_by(uuid: ai_annotation_params[:branch_from_uuid]) if ai_annotation_params[:branch_from_uuid].present?
@@ -66,6 +65,7 @@ class AiAnnotationsController < ApplicationController
   rescue => e
     Rails.logger.error "Error: #{e.message}"
     flash.now[:alert] = "Unexpected error occurred while generating AI annotation."
+    @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50, user: current_user) : []
     render :edit, status: :unprocessable_entity
   end
 

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -28,7 +28,7 @@ class AiAnnotationsController < ApplicationController
 
     ai_annotation = @new_ai_annotation.annotate! token, selected_api_key_uuid, selected_model, parent: parent
 
-    # セッションにゲストのヒストリを保存
+    # Save guest history to session
     save_to_guest_history(ai_annotation.uuid) unless user_signed_in?
 
     redirect_to edit_ai_annotation_path(ai_annotation.uuid, api_key_uuid: selected_api_key_uuid, model: selected_model)
@@ -64,7 +64,7 @@ class AiAnnotationsController < ApplicationController
 
     ai_annotation = @ai_annotation.annotate! token, selected_api_key_uuid, selected_model, parent: parent
 
-    # セッションにゲストのヒストリを保存
+    # Save guest history to session
     save_to_guest_history(ai_annotation.uuid) unless user_signed_in?
 
     redirect_to edit_ai_annotation_path(ai_annotation.uuid, api_key_uuid: selected_api_key_uuid, model: selected_model)
@@ -109,7 +109,7 @@ class AiAnnotationsController < ApplicationController
     session[:guest_ai_annotation_history] ||= []
     session[:guest_ai_annotation_history].unshift(uuid)
     session[:guest_ai_annotation_history].uniq!
-    # 最新50件に制限
+    # Limit to latest 50 items
     session[:guest_ai_annotation_history] = session[:guest_ai_annotation_history].first(50)
   end
 

--- a/app/controllers/ai_annotations_controller.rb
+++ b/app/controllers/ai_annotations_controller.rb
@@ -98,7 +98,7 @@ class AiAnnotationsController < ApplicationController
     @ai_annotation&.reload
     @history = user_signed_in? ? AiAnnotation.history_with_branches(limit: 50) : []
     render :edit, status: :unprocessable_entity
-　end
+  end
 
   def initialize_guest_history
     session[:guest_ai_annotation_history] ||= []


### PR DESCRIPTION
## 概要

このプルリクエストは、セッションベースの履歴管理を導入し、履歴取得ロジックをリファクタリングすることで、ゲストユーザー向けのサポートを改善するため、`AiAnnotationsController`を更新します。これらの変更により、ゲストユーザーはセッション中に注釈履歴を維持できるようになり、認証済みユーザーとの体験をより一致させます。さらに、ユーザートークンと履歴取得の処理において、明瞭さと一貫性を確保するためコードがリファクタリングされています。

**ゲストユーザーサポートとセッションベースの履歴:**

* ゲスト注釈履歴をセッション内で管理するため、`initialize_guest_history`、`save_to_guest_history`、`get_history` メソッドを追加。これによりゲストは自身の最近のAI注釈を表示・保存可能に。
* `create` および `update` アクションを更新し、ユーザーがサインインしていない場合、新規作成または更新された注釈の UUID をゲスト履歴に保存するようにしました。[[1]](diffhunk://#diff-7ecea1b5c5bbae81bfdcdb57257dbedb65627b6cb41d06258d2d5d9db1e4fd32L2-R48), [[2]](diffhunk://#diff-7ecea1b5c5bbae81bfdcdb57257dbedb65627b6cb41d06258d2d5d9db1e4fd32L54-R74)

**リファクタリングと一貫性の改善:**

* 認証済みユーザーとゲストユーザーの両方における履歴取得を統一するため、コントローラー全体で `AiAnnotation.history_with_branches` への直接呼び出しを新しい `get_history` メソッドに置き換えました。[[1]](diffhunk://#diff-7ecea1b5c5bbae81bfdcdb57257dbedb65627b6cb41d06258d2d5d9db1e4fd32L2-R48) [[2]](diffhunk://#diff-7ecea1b5c5bbae81bfdcdb57257dbedb65627b6cb41d06258d2d5d9db1e4fd32L54-R74)
* 条件分岐ロジックの代わりに `current_user&.id_token` を使用することでトークン取得を簡素化し、コードをより簡潔かつ堅牢にしました。[[1]](diffhunk://#diff-7ecea1b5c5bbae81bfdcdb57257dbedb65627b6cb41d06258d2d5d9db1e4fd32L2-R48) [[2]](diffhunk://#diff-7ecea1b5c5bbae81bfdcdb57257dbedb65627b6cb41d06258d2d5d9db1e4fd32L54-R74)